### PR TITLE
boot up module

### DIFF
--- a/atproto.xcodeproj/project.pbxproj
+++ b/atproto.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A15417A41A017B6D00D448B4 /* mqtt_client.c in Sources */ = {isa = PBXBuildFile; fileRef = A1438C3219F6E24200E40B50 /* mqtt_client.c */; };
 		A18881D819EDC4C000286BF7 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = A18881D719EDC4C000286BF7 /* README.md */; };
 		A1EEC32719DC812100E94BBC /* dce_basic_commands.c in Sources */ = {isa = PBXBuildFile; fileRef = A1EEC32119DC812100E94BBC /* dce_basic_commands.c */; };
 		A1EEC32A19DC812100E94BBC /* dce.c in Sources */ = {isa = PBXBuildFile; fileRef = A1EEC32419DC812100E94BBC /* dce.c */; };
@@ -245,6 +246,7 @@
 			files = (
 				A1EEC37F19DD7F7B00E94BBC /* tests.cpp in Sources */,
 				A1EEC37E19DD7F7B00E94BBC /* dce_test_commands.c in Sources */,
+				A15417A41A017B6D00D448B4 /* mqtt_client.c in Sources */,
 				A1EEC37D19DD7F7B00E94BBC /* test_dce_utils.cpp in Sources */,
 				A1EEC32C19DC812100E94BBC /* dce_utils.c in Sources */,
 				A1EEC32A19DC812100E94BBC /* dce.c in Sources */,

--- a/atproto.xcodeproj/project.pbxproj
+++ b/atproto.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		A13BCD1D19E3B83200C12FFB /* uart.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = uart.c; path = target/esp8266/uart.c; sourceTree = "<group>"; };
 		A13BCD1E19E3B83200C12FFB /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = main.c; path = target/esp8266/main.c; sourceTree = "<group>"; };
 		A13BCD2119E3CDFD00C12FFB /* uart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = uart.h; path = target/esp8266/uart.h; sourceTree = "<group>"; };
+		A1438C3219F6E24200E40B50 /* mqtt_client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mqtt_client.c; path = src/mqtt_client.c; sourceTree = "<group>"; };
+		A1438C3319F6E24200E40B50 /* mqtt_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mqtt_client.h; path = src/mqtt_client.h; sourceTree = "<group>"; };
 		A155471C19E470FF00E6425A /* dce_target.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dce_target.h; path = include/dce_target.h; sourceTree = "<group>"; };
 		A155471D19E5409E00E6425A /* interface_commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = interface_commands.c; path = target/esp8266/interface_commands.c; sourceTree = "<group>"; };
 		A155471E19E5409E00E6425A /* interface_commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = interface_commands.h; path = target/esp8266/interface_commands.h; sourceTree = "<group>"; };
@@ -141,6 +143,8 @@
 				A1EEC32419DC812100E94BBC /* dce.c */,
 				A1EEC33319DC814C00E94BBC /* dce.h */,
 				A155471C19E470FF00E6425A /* dce_target.h */,
+				A1438C3219F6E24200E40B50 /* mqtt_client.c */,
+				A1438C3319F6E24200E40B50 /* mqtt_client.h */,
 			);
 			name = src;
 			sourceTree = "<group>";

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1,0 +1,9 @@
+/* Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ * This file is part of the atproto AT protocol library
+ *
+ * Redistribution and use is permitted according to the conditions of the
+ * 3-clause BSD license to be found in the LICENSE file.
+ */
+
+
+#include "mqtt_client.h"

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -5,5 +5,55 @@
  * 3-clause BSD license to be found in the LICENSE file.
  */
 
-
+#include "dce_common.h"
 #include "mqtt_client.h"
+
+struct mqttc_
+{
+    mqttc_callback_t callback;
+    void* callback_arg;
+    const char* will_topic;
+    const char* will_payload;
+    int will_qos;
+    int will_retain;
+    const char* auth_user;
+    const char* auth_password;
+};
+
+mqttc_t* mqttc_create(mqttc_callback_t callback, void* callback_arg)
+{
+    mqttc_t* client = (mqttc_t*) malloc(sizeof(mqttc_t));
+    memset(client, 0, sizeof(mqttc_t));
+    client->callback = callback;
+    client->callback_arg = callback_arg;
+    return client;
+}
+
+void mqttc_release(mqttc_t* client)
+{
+    free(client);
+}
+
+void mqttc_set_will(mqttc_t* client, const char* topic, const char* payload, int qos, int retain)
+{
+    client->will_topic = topic;
+    client->will_payload = payload;
+    client->will_qos = qos;
+    client->will_retain = retain;
+}
+
+void mqttc_set_auth(mqttc_t* client, const char* user, const char* password)
+{
+    client->auth_user = user;
+    client->auth_password = password;
+}
+
+void mqttc_connect(mqttc_t* client, uint32_t ip, int port)
+{
+    
+}
+
+void mqttc_disconnect(mqttc_t* client);
+void mqttc_publish(mqttc_t* client, const char* topic, const char* payload, size_t payload_size, int retain);
+void mqttc_subscribe(mqttc_t* client, const char* topic, int qos);
+void mqttc_unsubscribe(mqttc_t* client, const char* topic);

--- a/src/mqtt_client.c
+++ b/src/mqtt_client.c
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
- * This file is part of the atproto AT protocol library
+ * This is a port of PubSubClient by Nicholas O'Leary in plain C99.
  *
  * Redistribution and use is permitted according to the conditions of the
  * 3-clause BSD license to be found in the LICENSE file.
@@ -7,6 +7,35 @@
 
 #include "dce_common.h"
 #include "mqtt_client.h"
+
+// MQTT_MAX_PACKET_SIZE : Maximum packet size
+#define MQTT_MAX_PACKET_SIZE 128
+
+// MQTT_KEEPALIVE : keepAlive interval in Seconds
+#define MQTT_KEEPALIVE 15
+
+enum { MQTT_PROTOCOL_VERSION=3 };
+
+enum mqtt_message_type_t
+{
+    MQTT_CONNECT = 1,
+    MQTT_CONNACK,
+    MQTT_PUBLISH,
+    MQTT_PUBACK,
+    MQTT_PUBREC,
+    MQTT_PUBREL,
+    MQTT_PUBCOMP,
+    MQTT_SUBSCRIBE,
+    MQTT_SUBACK,
+    MQTT_UNSUBSCRIBE,
+    MQTT_UNSUBACK,
+    MQTT_PINGREQ,
+    MQTT_PINGRESP,
+    MQTT_DISCONNECT,
+    MQTT_Reserved
+};
+
+enum { MQTT_TYPE_SHIFT = 4 };
 
 struct mqttc_
 {
@@ -18,6 +47,9 @@ struct mqttc_
     int will_retain;
     const char* auth_user;
     const char* auth_password;
+    uint16_t next_message_id;
+    uint8_t buffer[MQTT_MAX_PACKET_SIZE];
+    const char* id;
 };
 
 mqttc_t* mqttc_create(mqttc_callback_t callback, void* callback_arg)
@@ -48,10 +80,106 @@ void mqttc_set_auth(mqttc_t* client, const char* user, const char* password)
     client->auth_password = password;
 }
 
-void mqttc_connect(mqttc_t* client, uint32_t ip, int port)
+void mqttc_connect(mqttc_t* client, const char* id, uint32_t ip, int port)
 {
-    
+    client->id = id;
+    // tcp_connect(ip, port, &mqttc_on_connect, client);
 }
+
+void mqttc_append_str(uint8_t** pdst, const uint8_t* dstend, const char* src)
+{
+    size_t length = strlen(src);
+    uint8_t* dst = *pdst;
+    if (dst + 2 + length >= dstend)
+        DCE_FAIL("buffer size exceeded");
+    memcpy(dst + 2, src, length);
+    dst[0] = length >> 8;
+    dst[1] = length & 0xff;
+    *pdst = dst + 2 + length;
+}
+
+void mqttc_encode_remaining_length(uint8_t* dst, size_t value, size_t *out_length)
+{
+    uint8_t pos = 0;
+    uint8_t* p = dst;
+
+    for (; value; ++p)
+    {
+        uint8_t byte = value & 0x7f;
+        value >>= 7;
+        if (value)
+            byte |= 0x80;
+        *p = byte;
+    }
+    
+    *out_length = p - dst;
+}
+
+void mqttc_write(mqttc_t* client, uint8_t header, uint8_t* buf, const uint8_t* buf_end)
+{
+    uint8_t remaining_length_buffer[4];
+    size_t remaining_length_size;
+    size_t remaining_length = buf_end - buf;
+    mqttc_encode_remaining_length(remaining_length_buffer, remaining_length, &remaining_length_size);
+    uint8_t* msg_start = buf - 1 - (int)remaining_length_size;
+    size_t msg_size = 1 + remaining_length_size + remaining_length;
+    msg_start[0] = header;
+    memcpy(msg_start + 1, remaining_length_buffer, remaining_length_size);
+    // tcp_write(client->tcp_ctx, msg_start, msg_size, &mqttc_write_complete, client);
+}
+
+void mqttc_on_connect(mqttc_t* client)
+{
+    client->next_message_id = 1;
+    const uint8_t d[] = {0x00,0x06,'M','Q','I','s','d','p', MQTT_PROTOCOL_VERSION};
+    const size_t offset = 5;
+    uint8_t* pbuf = client->buffer + offset;
+    memcpy(pbuf, d, sizeof(d));
+    pbuf += sizeof(d);
+    uint8_t* buf_end = client->buffer + sizeof(client->buffer);
+
+    uint8_t v;
+    if (client->will_topic)
+    {
+        v = 0x06 | (client->will_qos << 3) | (client->will_retain << 5);
+    }
+    else
+    {
+        v = 0x02;
+    }
+    
+    if (client->auth_user)
+    {
+        v = v|0x80;
+        if(client->auth_password != NULL)
+        {
+            v = v | (0x80>>1);
+        }
+    }
+    
+    *pbuf++ = v;
+    *pbuf++ = ((MQTT_KEEPALIVE) >> 8);
+    *pbuf++ = ((MQTT_KEEPALIVE) & 0xFF);
+
+    mqttc_append_str(&pbuf, buf_end, client->id);
+    
+    if (client->will_topic) {
+        mqttc_append_str(&pbuf, buf_end, client->will_topic);
+        mqttc_append_str(&pbuf, buf_end, client->will_payload);
+    }
+    
+    if (client->auth_user != NULL)
+    {
+        mqttc_append_str(&pbuf, buf_end, client->auth_user);
+        if (client->auth_password != NULL)
+        {
+            mqttc_append_str(&pbuf, buf_end, client->auth_password);
+        }
+    }
+    mqttc_write(client, MQTT_CONNECT << MQTT_TYPE_SHIFT, pbuf, buf_end);
+}
+
+
 
 void mqttc_disconnect(mqttc_t* client);
 void mqttc_publish(mqttc_t* client, const char* topic, const char* payload, size_t payload_size, int retain);

--- a/src/mqtt_client.h
+++ b/src/mqtt_client.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ * This file is part of the atproto AT protocol library
+ *
+ * Redistribution and use is permitted according to the conditions of the
+ * 3-clause BSD license to be found in the LICENSE file.
+ */
+
+#ifndef MQTT_CLIENT_H
+#define MQTT_CLIENT_H
+
+
+#include <stdint.h>
+
+typedef struct mqttc_ mqttc_t;
+
+typedef void(*mqttc_callback_t)(void*, int, const char*, int);
+
+mqttc_t* mqttc_create(mqttc_callback_t callback, void* callback_arg);
+void mqttc_release(mqttc_t* client);
+void mqttc_set_will(const char* topic, const char* payload, int qos, int retain);
+void mqttc_set_auth(const char* user, const char* password);
+void mqttc_connect(uint32_t ip, int port);
+void mqttc_disconnect();
+void mqttc_publish(const char* topic, const char* payload, size_t payload_size, int retain);
+void mqttc_subscribe(const char* topic, int qos);
+void mqttc_unsubscribe(const char* topic);
+
+#endif//MQTT_CLIENT_H

--- a/src/mqtt_client.h
+++ b/src/mqtt_client.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
- * This file is part of the atproto AT protocol library
+ * This is a port of PubSubClient by Nicholas O'Leary in plain C99.
  *
  * Redistribution and use is permitted according to the conditions of the
  * 3-clause BSD license to be found in the LICENSE file.
@@ -19,7 +19,7 @@ mqttc_t* mqttc_create(mqttc_callback_t callback, void* callback_arg);
 void mqttc_release(mqttc_t* client);
 void mqttc_set_will(mqttc_t* client, const char* topic, const char* payload, int qos, int retain);
 void mqttc_set_auth(mqttc_t* client, const char* user, const char* password);
-void mqttc_connect(mqttc_t* client, uint32_t ip, int port);
+void mqttc_connect(mqttc_t* client, const char* id, uint32_t ip, int port);
 void mqttc_disconnect(mqttc_t* client);
 void mqttc_publish(mqttc_t* client, const char* topic, const char* payload, size_t payload_size, int retain);
 void mqttc_subscribe(mqttc_t* client, const char* topic, int qos);

--- a/src/mqtt_client.h
+++ b/src/mqtt_client.h
@@ -11,18 +11,18 @@
 
 #include <stdint.h>
 
-typedef struct mqttc_ mqttc_t;
-
 typedef void(*mqttc_callback_t)(void*, int, const char*, int);
+
+typedef struct mqttc_ mqttc_t;
 
 mqttc_t* mqttc_create(mqttc_callback_t callback, void* callback_arg);
 void mqttc_release(mqttc_t* client);
-void mqttc_set_will(const char* topic, const char* payload, int qos, int retain);
-void mqttc_set_auth(const char* user, const char* password);
-void mqttc_connect(uint32_t ip, int port);
-void mqttc_disconnect();
-void mqttc_publish(const char* topic, const char* payload, size_t payload_size, int retain);
-void mqttc_subscribe(const char* topic, int qos);
-void mqttc_unsubscribe(const char* topic);
+void mqttc_set_will(mqttc_t* client, const char* topic, const char* payload, int qos, int retain);
+void mqttc_set_auth(mqttc_t* client, const char* user, const char* password);
+void mqttc_connect(mqttc_t* client, uint32_t ip, int port);
+void mqttc_disconnect(mqttc_t* client);
+void mqttc_publish(mqttc_t* client, const char* topic, const char* payload, size_t payload_size, int retain);
+void mqttc_subscribe(mqttc_t* client, const char* topic, int qos);
+void mqttc_unsubscribe(mqttc_t* client, const char* topic);
 
 #endif//MQTT_CLIENT_H

--- a/target/host/tests.cpp
+++ b/target/host/tests.cpp
@@ -202,3 +202,29 @@ TEST_CASE("can reset dce even if command is pending", "[dce]")
     dce_uninit(dce);
 }
 
+typedef std::function<void(int)> func_t;
+
+typedef struct {
+    const char* name;
+    func_t func;
+} stage_t;
+
+void tcp_connect(int32_t ip, int16_t port) { }
+
+
+void on_connect(void* ctx)
+{
+    
+}
+
+TEST_CASE("continuations for mqtt")
+{
+    stage_t stages[] = {
+        {"connect", [&](int) {
+            uint8_t ip[] = {192, 168, 0, 1};
+            tcp_connect( *((int32_t*) ip), 54002 );
+            
+        }}
+    };
+}
+


### PR DESCRIPTION
I would like to suggest an official message send by the module when it's ready to work.
for now, I see 
<CR><LF>
+CWSTAT:1<CR><LF>
<CR><LF>
+CWSTAT:5<CR><LF>

maybe a better message would be
"ready - Ver 0.1 Rev b5dd82d <CR><LF>" ( with for sure the corresponding Ver/Rev )

like that, when we receive at least "ready", we know that the module cab accept commands
because +CWSTAT... is a reply to the command AT+CWSTAT. we don't expect this reply until we send the command !

thanks
Phil
