### PR TITLE
Make Makefile less location-dependent, port to fixed SDK 0.9.3, use flashi instead of esptool simplifying build

### DIFF
--- a/target/esp8266/driver/adc.h
+++ b/target/esp8266/driver/adc.h
@@ -1,0 +1,6 @@
+#ifndef __ADC_H__
+#define __ADC_H__
+
+uint16 adc_read(void);
+
+#endif

--- a/target/esp8266/driver/gpio16.h
+++ b/target/esp8266/driver/gpio16.h
@@ -1,0 +1,9 @@
+#ifndef __GPIO16_H__
+#define __GPIO16_H__
+
+void gpio16_output_conf(void);
+void gpio16_output_set(uint8 value);
+void gpio16_input_conf(void);
+uint8 gpio16_input_get(void);
+
+#endif

--- a/target/esp8266/driver/i2c_master.h
+++ b/target/esp8266/driver/i2c_master.h
@@ -1,0 +1,53 @@
+#ifndef __I2C_MASTER_H__
+#define __I2C_MASTER_H__
+
+#define I2C_MASTER_SDA_MUX PERIPHS_IO_MUX_GPIO2_U
+#define I2C_MASTER_SCL_MUX PERIPHS_IO_MUX_MTMS_U
+#define I2C_MASTER_SDA_GPIO 2
+#define I2C_MASTER_SCL_GPIO 14
+#define I2C_MASTER_SDA_FUNC FUNC_GPIO2
+#define I2C_MASTER_SCL_FUNC FUNC_GPIO14
+
+//#define I2C_MASTER_SDA_MUX PERIPHS_IO_MUX_GPIO2_U
+//#define I2C_MASTER_SCL_MUX PERIPHS_IO_MUX_GPIO0_U
+//#define I2C_MASTER_SDA_GPIO 2
+//#define I2C_MASTER_SCL_GPIO 0
+//#define I2C_MASTER_SDA_FUNC FUNC_GPIO2
+//#define I2C_MASTER_SCL_FUNC FUNC_GPIO0
+
+#if 0
+#define I2C_MASTER_GPIO_SET(pin)  \
+    gpio_output_set(1<<pin,0,1<<pin,0)
+
+#define I2C_MASTER_GPIO_CLR(pin) \
+    gpio_output_set(0,1<<pin,1<<pin,0)
+
+#define I2C_MASTER_GPIO_OUT(pin,val) \
+    if(val) I2C_MASTER_GPIO_SET(pin);\
+    else I2C_MASTER_GPIO_CLR(pin)
+#endif
+
+#define I2C_MASTER_SDA_HIGH_SCL_HIGH()  \
+    gpio_output_set(1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 0, 1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 0)
+
+#define I2C_MASTER_SDA_HIGH_SCL_LOW()  \
+    gpio_output_set(1<<I2C_MASTER_SDA_GPIO, 1<<I2C_MASTER_SCL_GPIO, 1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 0)
+
+#define I2C_MASTER_SDA_LOW_SCL_HIGH()  \
+    gpio_output_set(1<<I2C_MASTER_SCL_GPIO, 1<<I2C_MASTER_SDA_GPIO, 1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 0)
+
+#define I2C_MASTER_SDA_LOW_SCL_LOW()  \
+    gpio_output_set(0, 1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 1<<I2C_MASTER_SDA_GPIO | 1<<I2C_MASTER_SCL_GPIO, 0)
+
+void i2c_master_gpio_init(void);
+void i2c_master_init(void);
+
+#define i2c_master_wait    os_delay_us
+void i2c_master_stop(void);
+void i2c_master_start(void);
+void i2c_master_setAck(uint8 level);
+uint8 i2c_master_getAck(void);
+uint8 i2c_master_readByte(void);
+void i2c_master_writeByte(uint8 wrdata);
+
+#endif

--- a/target/esp8266/driver/key.h
+++ b/target/esp8266/driver/key.h
@@ -1,0 +1,27 @@
+#ifndef __KEY_H__
+#define __KEY_H__
+
+#include "gpio.h"
+
+typedef void (* key_function)(void);
+
+struct single_key_param {
+    uint8 key_level;
+    uint8 gpio_id;
+    uint8 gpio_func;
+    uint32 gpio_name;
+    os_timer_t key_5s;
+    os_timer_t key_50ms;
+    key_function short_press;
+    key_function long_press;
+};
+
+struct keys_param {
+    uint8 key_num;
+    struct single_key_param **single_key;
+};
+
+struct single_key_param *key_init_single(uint8 gpio_id, uint32 gpio_name, uint8 gpio_func, key_function long_press, key_function short_press);
+void key_init(struct keys_param *key);
+
+#endif

--- a/target/esp8266/driver/pwm.h
+++ b/target/esp8266/driver/pwm.h
@@ -1,0 +1,42 @@
+#ifndef __PWM_H__
+#define __PWM_H__
+
+#define PWM_CHANNEL 3
+
+struct pwm_single_param {
+	uint16 gpio_set;
+	uint16 gpio_clear;
+    uint16 h_time;
+};
+
+struct pwm_param {
+    uint16 period;
+    uint16 freq;
+    uint8  duty[PWM_CHANNEL];
+};
+
+#define PWM_DEPTH 255
+
+#define PWM_1S 1000000
+
+#define PWM_0_OUT_IO_MUX PERIPHS_IO_MUX_MTDI_U
+#define PWM_0_OUT_IO_NUM 12
+#define PWM_0_OUT_IO_FUNC  FUNC_GPIO12
+
+#define PWM_1_OUT_IO_MUX PERIPHS_IO_MUX_MTDO_U
+#define PWM_1_OUT_IO_NUM 15
+#define PWM_1_OUT_IO_FUNC  FUNC_GPIO15
+
+#define PWM_2_OUT_IO_MUX PERIPHS_IO_MUX_MTCK_U
+#define PWM_2_OUT_IO_NUM 13
+#define PWM_2_OUT_IO_FUNC  FUNC_GPIO13
+
+void pwm_init(uint16 freq, uint8 *duty);
+void pwm_start(void);
+
+void pwm_set_duty(uint8 duty, uint8 channel);
+uint8 pwm_get_duty(uint8 channel);
+void pwm_set_freq(uint16 freq);
+uint16 pwm_get_freq(void);
+#endif
+

--- a/target/esp8266/driver/spi_master.h
+++ b/target/esp8266/driver/spi_master.h
@@ -1,0 +1,13 @@
+#ifndef __SPI_MASTER_H__
+#define __SPI_MASTER_H__
+
+#include "driver/spi_register.h"
+
+/*SPI number define*/
+#define SPI         0
+#define HSPI        1
+
+void spi_master_init(uint8 spi_no);
+void spi_master_9bit_write(uint8 spi_no, uint8 high_bit, uint8 low_8bit);
+
+#endif

--- a/target/esp8266/driver/spi_register.h
+++ b/target/esp8266/driver/spi_register.h
@@ -1,0 +1,235 @@
+//Generated at 2014-07-29 11:03:29
+/*
+ *  Copyright (c) 2010 - 2011 Espressif System
+ *
+ */
+
+#ifndef SPI_REGISTER_H_INCLUDED
+#define SPI_REGISTER_H_INCLUDED
+
+#define REG_SPI_BASE(i)  (0x60000200-i*0x100)
+#define SPI_FLASH_CMD(i)                            (REG_SPI_BASE(i)  + 0x0)
+#define SPI_FLASH_READ (BIT(31))
+#define SPI_FLASH_WREN (BIT(30))
+#define SPI_FLASH_WRDI (BIT(29))
+#define SPI_FLASH_RDID (BIT(28))
+#define SPI_FLASH_RDSR (BIT(27))
+#define SPI_FLASH_WRSR (BIT(26))
+#define SPI_FLASH_PP (BIT(25))
+#define SPI_FLASH_SE (BIT(24))
+#define SPI_FLASH_BE (BIT(23))
+#define SPI_FLASH_CE (BIT(22))
+#define SPI_FLASH_DP (BIT(21))
+#define SPI_FLASH_RES (BIT(20))
+#define SPI_FLASH_HPM (BIT(19))
+#define SPI_FLASH_USR (BIT(18))
+#define SPI_FLASH_ADDR(i)                           (REG_SPI_BASE(i)  + 0x4)
+#define SPI_FLASH_CTRL(i)                           (REG_SPI_BASE(i)  + 0x8)
+#define SPI_WR_BIT_ODER (BIT(26))
+#define SPI_RD_BIT_ODER (BIT(25))
+#define SPI_QIO_MODE (BIT(24))
+#define SPI_DIO_MODE (BIT(23))
+#define SPI_TWO_BYTE_STATUS_EN (BIT(22))
+#define SPI_WP_REG (BIT(21))
+#define SPI_QOUT_MODE (BIT(20))
+#define SPI_SHARE_BUS (BIT(19))
+#define SPI_HOLD_MODE (BIT(18))
+#define SPI_ENABLE_AHB (BIT(17))
+#define SPI_SST_AAI (BIT(16))
+#define SPI_RESANDRES (BIT(15))
+#define SPI_DOUT_MODE (BIT(14))
+#define SPI_FASTRD_MODE (BIT(13))
+#define SPI_FLASH_CTRL1(i)                          (REG_SPI_BASE (i) + 0xC)
+#define SPI_T_CSH 0x0000000F
+#define SPI_T_CSH_S 28
+#define SPI_T_RES 0x00000FFF
+#define SPI_T_RES_S 16
+#define SPI_BUS_TIMER_LIMIT 0x0000FFFF
+#define SPI_BUS_TIMER_LIMIT_S 0
+
+#define SPI_FLASH_STATUS(i)                         (REG_SPI_BASE(i)  + 0x10)
+#define SPI_STATUS_EXT 0x000000FF
+#define SPI_STATUS_EXT_S 24
+#define SPI_WB_MODE 0x000000FF
+#define SPI_WB_MODE_S 16
+#define SPI_FLASH_STATUS_PRO_FLAG (BIT(7))
+#define SPI_FLASH_TOP_BOT_PRO_FLAG (BIT(5))
+#define SPI_FLASH_BP2 (BIT(4))
+#define SPI_FLASH_BP1 (BIT(3))
+#define SPI_FLASH_BP0 (BIT(2))
+#define SPI_FLASH_WRENABLE_FLAG (BIT(1))
+#define SPI_FLASH_BUSY_FLAG (BIT(0))
+
+#define SPI_FLASH_CTRL2(i)                          (REG_SPI_BASE(i)  + 0x14)
+#define SPI_CS_DELAY_NUM 0x0000000F
+#define SPI_CS_DELAY_NUM_S 28
+#define SPI_CS_DELAY_MODE 0x00000003
+#define SPI_CS_DELAY_MODE_S 26
+#define SPI_MOSI_DELAY_NUM 0x00000007
+#define SPI_MOSI_DELAY_NUM_S 23
+#define SPI_MOSI_DELAY_MODE 0x00000003
+#define SPI_MOSI_DELAY_MODE_S 21
+#define SPI_MISO_DELAY_NUM 0x00000007
+#define SPI_MISO_DELAY_NUM_S 18
+#define SPI_MISO_DELAY_MODE 0x00000003
+#define SPI_MISO_DELAY_MODE_S 16
+#define SPI_CK_OUT_HIGH_MODE 0x0000000F
+#define SPI_CK_OUT_HIGH_MODE_S 12
+#define SPI_CK_OUT_LOW_MODE 0x0000000F
+#define SPI_CK_OUT_LOW_MODE_S 8
+#define SPI_HOLD_TIME 0x0000000F
+#define SPI_HOLD_TIME_S 4
+#define SPI_SETUP_TIME 0x0000000F
+#define SPI_SETUP_TIME_S 0
+
+#define SPI_FLASH_CLOCK(i)                          (REG_SPI_BASE(i)  + 0x18)
+#define SPI_CLK_EQU_SYSCLK (BIT(31))
+#define SPI_CLKDIV_PRE 0x00001FFF
+#define SPI_CLKDIV_PRE_S 18
+#define SPI_CLKCNT_N 0x0000003F
+#define SPI_CLKCNT_N_S 12
+#define SPI_CLKCNT_H 0x0000003F
+#define SPI_CLKCNT_H_S 6
+#define SPI_CLKCNT_L 0x0000003F
+#define SPI_CLKCNT_L_S 0
+
+#define SPI_FLASH_USER(i)                           (REG_SPI_BASE(i)  + 0x1C)
+#define SPI_USR_COMMAND (BIT(31))
+#define SPI_FLASH_USR_ADDR (BIT(30))
+#define SPI_FLASH_USR_DUMMY (BIT(29))
+#define SPI_FLASH_USR_DIN (BIT(28))
+#define SPI_FLASH_DOUT (BIT(27))
+#define SPI_USR_DUMMY_IDLE (BIT(26))
+#define SPI_USR_DOUT_HIGHPART (BIT(25))
+#define SPI_USR_DIN_HIGHPART (BIT(24))
+#define SPI_USR_PREP_HOLD (BIT(23))
+#define SPI_USR_CMD_HOLD (BIT(22))
+#define SPI_USR_ADDR_HOLD (BIT(21))
+#define SPI_USR_DUMMY_HOLD (BIT(20))
+#define SPI_USR_DIN_HOLD (BIT(19))
+#define SPI_USR_DOUT_HOLD (BIT(18))
+#define SPI_USR_HOLD_POL (BIT(17))
+#define SPI_SIO (BIT(16))
+#define SPI_FWRITE_QIO (BIT(15))
+#define SPI_FWRITE_DIO (BIT(14))
+#define SPI_FWRITE_QUAD (BIT(13))
+#define SPI_FWRITE_DUAL (BIT(12))
+#define SPI_WR_BYTE_ORDER (BIT(11))
+#define SPI_RD_BYTE_ORDER (BIT(10))
+#define SPI_AHB_ENDIAN_MODE 0x00000003
+#define SPI_AHB_ENDIAN_MODE_S 8
+#define SPI_CK_OUT_EDGE (BIT(7))
+#define SPI_CK_I_EDGE (BIT(6))
+#define SPI_CS_SETUP (BIT(5))
+#define SPI_CS_HOLD (BIT(4))
+#define SPI_AHB_USR_COMMAND (BIT(3))
+#define SPI_AHB_USR_COMMAND_4BYTE (BIT(1))
+#define SPI_DOUTDIN (BIT(0))
+
+#define SPI_FLASH_USER1(i)                          (REG_SPI_BASE(i) + 0x20)
+#define SPI_USR_ADDR_BITLEN 0x0000003F
+#define SPI_USR_ADDR_BITLEN_S 26
+#define SPI_USR_OUT_BITLEN 0x000001FF
+#define SPI_USR_OUT_BITLEN_S 17
+#define SPI_USR_DIN_BITLEN 0x000001FF
+#define SPI_USR_DIN_BITLEN_S 8
+#define SPI_USR_DUMMY_CYCLELEN 0x000000FF
+#define SPI_USR_DUMMY_CYCLELEN_S 0
+
+#define SPI_FLASH_USER2(i)                          (REG_SPI_BASE(i)  + 0x24)
+#define SPI_USR_COMMAND_BITLEN 0x0000000F
+#define SPI_USR_COMMAND_BITLEN_S 28
+#define SPI_USR_COMMAND_VALUE 0x0000FFFF
+#define SPI_USR_COMMAND_VALUE_S 0
+
+#define SPI_FLASH_USER3(i)                          (REG_SPI_BASE(i)  + 0x28)
+#define SPI_FLASH_PIN(i)                            (REG_SPI_BASE(i)  + 0x2C)
+#define SPI_FLASH_SLAVE(i)                          (REG_SPI_BASE(i)  + 0x30)
+#define SPI_SYNC_RESET (BIT(31))
+#define SPI_SLAVE_MODE (BIT(30))
+#define SPI_SLV_WR_RD_BUF_EN (BIT(29))
+#define SPI_SLV_WR_RD_STA_EN (BIT(28))
+#define SPI_SLV_CMD_DEFINE (BIT(27))
+#define SPI_TRANS_CNT 0x0000000F
+#define SPI_TRANS_CNT_S 23
+#define SPI_SLV_LAST_STATE 0x00000007
+#define SPI_SLV_LAST_STATE_S 20
+#define SPI_SLV_LAST_COMMAND 0x00000007
+#define SPI_SLV_LAST_COMMAND_S 17
+#define SPI_CS_I_MODE 0x00000003
+#define SPI_CS_I_MODE_S 10
+#define SPI_INT_EN 0x0000001F
+#define SPI_INT_EN_S 5
+#define SPI_TRANS_DONE (BIT(4))
+#define SPI_SLV_WR_STA_DONE (BIT(3))
+#define SPI_SLV_RD_STA_DONE (BIT(2))
+#define SPI_SLV_WR_BUF_DONE (BIT(1))
+#define SPI_SLV_RD_BUF_DONE (BIT(0))
+
+#define SPI_FLASH_SLAVE1(i)                         (REG_SPI_BASE(i)  + 0x34)
+#define SPI_SLV_STATUS_BITLEN 0x0000001F
+#define SPI_SLV_STATUS_BITLEN_S 27
+#define SPI_SLV_STATUS_FAST_EN (BIT(26))
+#define SPI_SLV_STATUS_READBACK (BIT(25))
+#define SPI_SLV_BUF_BITLEN 0x000001FF
+#define SPI_SLV_BUF_BITLEN_S 16
+#define SPI_SLV_RD_ADDR_BITLEN 0x0000003F
+#define SPI_SLV_RD_ADDR_BITLEN_S 10
+#define SPI_SLV_WR_ADDR_BITLEN 0x0000003F
+#define SPI_SLV_WR_ADDR_BITLEN_S 4
+#define SPI_SLV_WRSTA_DUMMY_EN (BIT(3))
+#define SPI_SLV_RDSTA_DUMMY_EN (BIT(2))
+#define SPI_SLV_WRBUF_DUMMY_EN (BIT(1))
+#define SPI_SLV_RDBUF_DUMMY_EN (BIT(0))
+
+#define SPI_FLASH_SLAVE2(i)                         (REG_SPI_BASE(i)  + 0x38)
+#define SPI_SLV_WRBUF_DUMMY_CYCLELEN 0x000000FF
+#define SPI_SLV_WRBUF_DUMMY_CYCLELEN_S 24
+#define SPI_SLV_RDBUF_DUMMY_CYCLELEN 0x000000FF
+#define SPI_SLV_RDBUF_DUMMY_CYCLELEN_S 16
+#define SPI_SLV_WRSTA_DUMMY_CYCLELEN 0x000000FF
+#define SPI_SLV_WRSTA_DUMMY_CYCLELEN_S 8
+#define SPI_SLV_RDSTA_DUMMY_CYCLELEN 0x000000FF
+#define SPI_SLV_RDSTA_DUMMY_CYCLELEN_S 0
+
+#define SPI_FLASH_SLAVE3(i)                         (REG_SPI_BASE(i)  + 0x3C)
+#define SPI_SLV_WRSTA_CMD_VALUE 0x000000FF
+#define SPI_SLV_WRSTA_CMD_VALUE_S 24
+#define SPI_SLV_RDSTA_CMD_VALUE 0x000000FF
+#define SPI_SLV_RDSTA_CMD_VALUE_S 16
+#define SPI_SLV_WRBUF_CMD_VALUE 0x000000FF
+#define SPI_SLV_WRBUF_CMD_VALUE_S 8
+#define SPI_SLV_RDBUF_CMD_VALUE 0x000000FF
+#define SPI_SLV_RDBUF_CMD_VALUE_S 0
+
+#define SPI_FLASH_C0(i) 							(REG_SPI_BASE(i) +0x40)
+#define SPI_FLASH_C1(i) 							(REG_SPI_BASE(i) +0x44)
+#define SPI_FLASH_C2(i) 							(REG_SPI_BASE(i) +0x48)
+#define SPI_FLASH_C3(i) 							(REG_SPI_BASE(i) +0x4C)
+#define SPI_FLASH_C4(i) 							(REG_SPI_BASE(i) +0x50)
+#define SPI_FLASH_C5(i) 							(REG_SPI_BASE(i) +0x54)
+#define SPI_FLASH_C6(i) 							(REG_SPI_BASE(i) +0x58)
+#define SPI_FLASH_C7(i) 							(REG_SPI_BASE(i) +0x5C)
+
+#define SPI_FLASH_EXT0(i)                           (REG_SPI_BASE(i)  + 0xF0)
+#define SPI_T_PP_ENA (BIT(31))
+#define SPI_T_PP_SHIFT 0x0000000F
+#define SPI_T_PP_SHIFT_S 16
+#define SPI_T_PP_TIME 0x00000FFF
+#define SPI_T_PP_TIME_S 0
+
+#define SPI_FLASH_EXT1(i)                          (REG_SPI_BASE(i)  + 0xF4)
+#define SPI_T_ERASE_ENA (BIT(31))
+#define SPI_T_ERASE_SHIFT 0x0000000F
+#define SPI_T_ERASE_SHIFT_S 16
+#define SPI_T_ERASE_TIME 0x00000FFF
+#define SPI_T_ERASE_TIME_S 0
+
+#define SPI_FLASH_EXT2(i)                           (REG_SPI_BASE(i)  + 0xF8)
+#define SPI_ST 0x00000007
+#define SPI_ST_S 0
+
+#define SPI_FLASH_EXT3(i)                           (REG_SPI_BASE(i)  + 0xFC)
+#define SPI_INT_HOLD_ENA 0x00000003
+#define SPI_INT_HOLD_ENA_S 0
+#endif // SPI_REGISTER_H_INCLUDED

--- a/target/esp8266/driver/uart.h
+++ b/target/esp8266/driver/uart.h
@@ -1,0 +1,96 @@
+#ifndef UART_APP_H
+#define UART_APP_H
+
+#include "uart_register.h"
+
+#define RX_BUFF_SIZE    0x100
+#define TX_BUFF_SIZE    100
+
+typedef enum {
+    FIVE_BITS = 0x0,
+    SIX_BITS = 0x1,
+    SEVEN_BITS = 0x2,
+    EIGHT_BITS = 0x3
+} UartBitsNum4Char;
+
+typedef enum {
+    ONE_STOP_BIT             = 0,
+    ONE_HALF_STOP_BIT        = BIT2,
+    TWO_STOP_BIT             = BIT2
+} UartStopBitsNum;
+
+typedef enum {
+    NONE_BITS = 0,
+    ODD_BITS   = 0,
+    EVEN_BITS = BIT4
+} UartParityMode;
+
+typedef enum {
+    STICK_PARITY_DIS   = 0,
+    STICK_PARITY_EN    = BIT3 | BIT5
+} UartExistParity;
+
+typedef enum {
+    BIT_RATE_9600     = 9600,
+    BIT_RATE_19200   = 19200,
+    BIT_RATE_38400   = 38400,
+    BIT_RATE_57600   = 57600,
+    BIT_RATE_74880   = 74880,
+    BIT_RATE_115200 = 115200,
+    BIT_RATE_230400 = 230400,
+    BIT_RATE_460800 = 460800,
+    BIT_RATE_921600 = 921600
+} UartBautRate;
+
+typedef enum {
+    NONE_CTRL,
+    HARDWARE_CTRL,
+    XON_XOFF_CTRL
+} UartFlowCtrl;
+
+typedef enum {
+    EMPTY,
+    UNDER_WRITE,
+    WRITE_OVER
+} RcvMsgBuffState;
+
+typedef struct {
+    uint32     RcvBuffSize;
+    uint8     *pRcvMsgBuff;
+    uint8     *pWritePos;
+    uint8     *pReadPos;
+    uint8      TrigLvl; //JLU: may need to pad
+    RcvMsgBuffState  BuffState;
+} RcvMsgBuff;
+
+typedef struct {
+    uint32   TrxBuffSize;
+    uint8   *pTrxBuff;
+} TrxMsgBuff;
+
+typedef enum {
+    BAUD_RATE_DET,
+    WAIT_SYNC_FRM,
+    SRCH_MSG_HEAD,
+    RCV_MSG_BODY,
+    RCV_ESC_CHAR,
+} RcvMsgState;
+
+typedef struct {
+    UartBautRate 	     baut_rate;
+    UartBitsNum4Char  data_bits;
+    UartExistParity      exist_parity;
+    UartParityMode 	    parity;    // chip size in byte
+    UartStopBitsNum   stop_bits;
+    UartFlowCtrl         flow_ctrl;
+    RcvMsgBuff          rcv_buff;
+    TrxMsgBuff           trx_buff;
+    RcvMsgState        rcv_state;
+    int                      received;
+    int                      buff_uart_no;  //indicate which uart use tx/rx buffer
+} UartDevice;
+
+void uart_init(UartBautRate uart0_br, UartBautRate uart1_br);
+
+#endif
+

--- a/target/esp8266/driver/uart_register.h
+++ b/target/esp8266/driver/uart_register.h
@@ -1,0 +1,128 @@
+//Generated at 2012-07-03 18:44:06
+/*
+ *  Copyright (c) 2010 - 2011 Espressif System
+ *
+ */
+
+#ifndef UART_REGISTER_H_INCLUDED
+#define UART_REGISTER_H_INCLUDED
+#define REG_UART_BASE( i )  (0x60000000+(i)*0xf00)
+//version value:32'h062000
+
+#define UART_FIFO( i )                          (REG_UART_BASE( i ) + 0x0)
+#define UART_RXFIFO_RD_BYTE 0x000000FF
+#define UART_RXFIFO_RD_BYTE_S 0
+
+#define UART_INT_RAW( i )                       (REG_UART_BASE( i ) + 0x4)
+#define UART_RXFIFO_TOUT_INT_RAW (BIT(8))
+#define UART_BRK_DET_INT_RAW (BIT(7))
+#define UART_CTS_CHG_INT_RAW (BIT(6))
+#define UART_DSR_CHG_INT_RAW (BIT(5))
+#define UART_RXFIFO_OVF_INT_RAW (BIT(4))
+#define UART_FRM_ERR_INT_RAW (BIT(3))
+#define UART_PARITY_ERR_INT_RAW (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_RAW (BIT(1))
+#define UART_RXFIFO_FULL_INT_RAW (BIT(0))
+
+#define UART_INT_ST( i )                        (REG_UART_BASE( i ) + 0x8)
+#define UART_RXFIFO_TOUT_INT_ST (BIT(8))
+#define UART_BRK_DET_INT_ST (BIT(7))
+#define UART_CTS_CHG_INT_ST (BIT(6))
+#define UART_DSR_CHG_INT_ST (BIT(5))
+#define UART_RXFIFO_OVF_INT_ST (BIT(4))
+#define UART_FRM_ERR_INT_ST (BIT(3))
+#define UART_PARITY_ERR_INT_ST (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_ST (BIT(1))
+#define UART_RXFIFO_FULL_INT_ST (BIT(0))
+
+#define UART_INT_ENA( i )                       (REG_UART_BASE( i ) + 0xC)
+#define UART_RXFIFO_TOUT_INT_ENA (BIT(8))
+#define UART_BRK_DET_INT_ENA (BIT(7))
+#define UART_CTS_CHG_INT_ENA (BIT(6))
+#define UART_DSR_CHG_INT_ENA (BIT(5))
+#define UART_RXFIFO_OVF_INT_ENA (BIT(4))
+#define UART_FRM_ERR_INT_ENA (BIT(3))
+#define UART_PARITY_ERR_INT_ENA (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_ENA (BIT(1))
+#define UART_RXFIFO_FULL_INT_ENA (BIT(0))
+
+#define UART_INT_CLR( i )                       (REG_UART_BASE( i ) + 0x10)
+#define UART_RXFIFO_TOUT_INT_CLR (BIT(8))
+#define UART_BRK_DET_INT_CLR (BIT(7))
+#define UART_CTS_CHG_INT_CLR (BIT(6))
+#define UART_DSR_CHG_INT_CLR (BIT(5))
+#define UART_RXFIFO_OVF_INT_CLR (BIT(4))
+#define UART_FRM_ERR_INT_CLR (BIT(3))
+#define UART_PARITY_ERR_INT_CLR (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_CLR (BIT(1))
+#define UART_RXFIFO_FULL_INT_CLR (BIT(0))
+
+#define UART_CLKDIV( i )                        (REG_UART_BASE( i ) + 0x14)
+#define UART_CLKDIV_CNT 0x000FFFFF
+#define UART_CLKDIV_S 0
+
+#define UART_AUTOBAUD( i )                      (REG_UART_BASE( i ) + 0x18)
+#define UART_GLITCH_FILT 0x000000FF
+#define UART_GLITCH_FILT_S 8
+#define UART_AUTOBAUD_EN (BIT(0))
+
+#define UART_STATUS( i )                        (REG_UART_BASE( i ) + 0x1C)
+#define UART_TXD (BIT(31))
+#define UART_RTSN (BIT(30))
+#define UART_DTRN (BIT(29))
+#define UART_TXFIFO_CNT 0x000000FF
+#define UART_TXFIFO_CNT_S 16
+#define UART_RXD (BIT(15))
+#define UART_CTSN (BIT(14))
+#define UART_DSRN (BIT(13))
+#define UART_RXFIFO_CNT 0x000000FF
+#define UART_RXFIFO_CNT_S 0
+
+#define UART_CONF0( i )                         (REG_UART_BASE( i ) + 0x20)
+#define UART_TXFIFO_RST (BIT(18))
+#define UART_RXFIFO_RST (BIT(17))
+#define UART_IRDA_EN (BIT(16))
+#define UART_TX_FLOW_EN (BIT(15))
+#define UART_LOOPBACK (BIT(14))
+#define UART_IRDA_RX_INV (BIT(13))
+#define UART_IRDA_TX_INV (BIT(12))
+#define UART_IRDA_WCTL (BIT(11))
+#define UART_IRDA_TX_EN (BIT(10))
+#define UART_IRDA_DPLX (BIT(9))
+#define UART_TXD_BRK (BIT(8))
+#define UART_SW_DTR (BIT(7))
+#define UART_SW_RTS (BIT(6))
+#define UART_STOP_BIT_NUM 0x00000003
+#define UART_STOP_BIT_NUM_S 4
+#define UART_BIT_NUM 0x00000003
+#define UART_BIT_NUM_S 2
+#define UART_PARITY_EN (BIT(1))
+#define UART_PARITY (BIT(0))
+
+#define UART_CONF1( i )                         (REG_UART_BASE( i ) + 0x24)
+#define UART_RX_TOUT_EN (BIT(31))
+#define UART_RX_TOUT_THRHD 0x0000007F
+#define UART_RX_TOUT_THRHD_S 24
+#define UART_RX_FLOW_EN (BIT(23))
+#define UART_RX_FLOW_THRHD 0x0000007F
+#define UART_RX_FLOW_THRHD_S 16
+#define UART_TXFIFO_EMPTY_THRHD 0x0000007F
+#define UART_TXFIFO_EMPTY_THRHD_S 8
+#define UART_RXFIFO_FULL_THRHD 0x0000007F
+#define UART_RXFIFO_FULL_THRHD_S 0
+
+#define UART_LOWPULSE( i )                      (REG_UART_BASE( i ) + 0x28)
+#define UART_LOWPULSE_MIN_CNT         0x000FFFFF
+#define UART_LOWPULSE_MIN_CNT_S     0
+
+#define UART_HIGHPULSE( i )                     (REG_UART_BASE( i ) + 0x2C)
+#define UART_HIGHPULSE_MIN_CNT         0x000FFFFF
+#define UART_HIGHPULSE_MIN_CNT_S     0
+
+#define UART_PULSE_NUM( i )                     (REG_UART_BASE( i ) + 0x30)
+#define UART_PULSE_NUM_CNT                  0x0003FF
+#define UART_PULSE_NUM_CNT_S               0
+
+#define UART_DATE( i )                          (REG_UART_BASE( i ) + 0x78)
+#define UART_ID( i )                            (REG_UART_BASE( i ) + 0x7C)
+#endif // UART_REGISTER_H_INCLUDED

--- a/target/esp8266/ip_commands_socket.c
+++ b/target/esp8266/ip_commands_socket.c
@@ -155,7 +155,7 @@ void SECTION_ATTR ip_tcp_disconnect_callback(struct espconn* connection)
     dce_emit_extended_result_code_with_args(arg->ctx->dce, "CIPDISCONNECT", -1, &res, 1, 0);
 }
 
-void SECTION_ATTR ip_tcp_reconnect_callback(struct espconn* connection, sint8 err)
+void SECTION_ATTR ip_tcp_reconnect_callback(struct espconn* connection, int8_t err)
 {
     ip_connection_t* arg = (ip_connection_t*) connection->reverse;
     arg_t res[] = {

--- a/target/esp8266/target.mk
+++ b/target/esp8266/target.mk
@@ -43,7 +43,7 @@ LDFLAGS  += -L$(XTENSA_LIBS)/lib \
 CFLAGS+=-std=c99
 CPPFLAGS+=-DESP_PLATFORM=1
 
-LIBS := c gcc hal phy net80211 lwip wpa main json ssl upgrade upgrade_ssl
+LIBS := c gcc hal phy net80211 lwip wpa main json ssl pp
 
 #-Werror 
 CFLAGS += -Os -g -O2 -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mno-text-section-literals  -D__ets__ -DICACHE_FLASH

--- a/target/esp8266/target.mk
+++ b/target/esp8266/target.mk
@@ -23,7 +23,7 @@ XTENSA_LIBS ?= $(shell $(CC) -print-sysroot)
 
 ESPTOOL ?= ../esptool/esptool
 
-SDK_BASE ?= ../esp_iot_sdk_v0.9.2
+SDK_BASE ?= ../esp_iot_sdk_v0.9.3
 
 SDK_AT_DIR := $(SDK_BASE)/examples/at
 

--- a/target/esp8266/target.mk
+++ b/target/esp8266/target.mk
@@ -12,16 +12,18 @@ TARGET_OBJ_FILES := main.o \
 
 TARGET_OBJ_PATHS := $(addprefix $(TARGET_DIR)/,$(TARGET_OBJ_FILES))
 
+TOOLCHAIN_PREFIX ?= xtensa-lx106-elf-
 XTENSA_TOOCHAIN := ../xtensa-lx106-elf/bin
-CC := $(XTENSA_TOOCHAIN)/xtensa-lx106-elf-gcc
-AR := $(XTENSA_TOOCHAIN)/xtensa-lx106-elf-ar
-LD := $(XTENSA_TOOCHAIN)/xtensa-lx106-elf-gcc
+CC := $(TOOLCHAIN_PREFIX)gcc
+AR := $(TOOLCHAIN_PREFIX)ar
+LD := $(TOOLCHAIN_PREFIX)gcc
 
-XTENSA_LIBS := ../RC-2010.1-linux/lx106/xtensa-elf
 
-ESPTOOL := ../esptool/esptool
+XTENSA_LIBS ?= $(shell $(CC) -print-sysroot)
 
-SDK_BASE := ../esp_iot_sdk_v0.9.2
+ESPTOOL ?= ../esptool/esptool
+
+SDK_BASE ?= ../esp_iot_sdk_v0.9.2
 
 SDK_AT_DIR := $(SDK_BASE)/examples/at
 
@@ -30,7 +32,9 @@ SDK_DRIVER_OBJ_PATHS := $(addprefix $(SDK_AT_DIR)/driver/,$(SDK_DRIVER_OBJ_FILES
 
 CPPFLAGS += -I$(XTENSA_LIBS)/include \
 			-I$(SDK_BASE)/include \
-			-I$(SDK_AT_DIR)/include
+			-I$(SDK_AT_DIR)/include \
+			-Itarget/esp8266/driver \
+			-Itarget/esp8266
 
 LDFLAGS  += -L$(XTENSA_LIBS)/lib \
 			-L$(XTENSA_LIBS)/arch/lib \

--- a/target/esp8266/target.mk
+++ b/target/esp8266/target.mk
@@ -18,6 +18,7 @@ CC := $(TOOLCHAIN_PREFIX)gcc
 AR := $(TOOLCHAIN_PREFIX)ar
 LD := $(TOOLCHAIN_PREFIX)gcc
 
+ESPTOOL ?= ../esptool/esptool.py
 
 XTENSA_LIBS ?= $(shell $(CC) -print-sysroot)
 
@@ -66,6 +67,12 @@ $(APP_OUT): $(APP_AR)
 	$(LD) -T$(LD_SCRIPT) $(LDFLAGS) -Wl,--start-group $(addprefix -l,$(LIBS)) $(APP_AR) -Wl,--end-group -o $@
 
 firmware: $(APP_OUT)
+
+split_image: firmware
+	$(ESPTOOL) make_split_image $(APP_OUT) $(APP_FW_1) $(APP_FW_2)
+
+image: firmware
+	$(ESPTOOL) make_image $(APP_OUT) $(FULL_FW)
 
 all: firmware
 

--- a/target/esp8266/uart.c
+++ b/target/esp8266/uart.c
@@ -24,7 +24,7 @@ void ICACHE_FLASH_ATTR uart0_rx_handler(uart_t* uart)
 {
     if (READ_PERI_REG(UART_INT_ST(0)) & UART_RXFIFO_FULL_INT_ST)
     {
-        while(true)
+        while (1)
         {
             int rx_count = (READ_PERI_REG(UART_STATUS(0)) >> UART_RXFIFO_CNT_S) & UART_RXFIFO_CNT;
             if (!rx_count)
@@ -42,7 +42,7 @@ void ICACHE_FLASH_ATTR uart0_rx_handler(uart_t* uart)
 
 void ICACHE_FLASH_ATTR uart0_wait_for_tx_fifo(size_t size_needed)
 {
-    while (true)
+    while (1)
     {
         size_t tx_count = (READ_PERI_REG(UART_STATUS(0)) >> UART_TXFIFO_CNT_S) & UART_TXFIFO_CNT;
         if (tx_count <= (UART_TX_FIFO_SIZE - size_needed))


### PR DESCRIPTION
Hi,
so here is a bunch of changes that were stacking up over here.
- The first commit (9357a82) is fixing the Makefile to be less position-depentdent by just asking the binutils for paths.
- The second commit adds a few headers for the drivers that were needed for building (I might try to remove these again in the future).
- The third commit (6fdaea6) includes fixes to build against the fixed version of espressif's SDK version 0.9.3 that can be found here: https://github.com/jaseg/espressif-esp8266-sdk . The main change there is the removal of the non-standard integer typedefs previously found in c_types.h.
- The fourth commit modifies the esp8266 makefile to just output an elf file that can later directly be passed to my modified version of upstream esptool.py and esptool-ck, dubbed flashi (since there are already enough esptools on this planet): https://github.com/jaseg/flashi

BTW, I successfully built this firmware against https://github.com/tommie/lx106-hal .

Best regards,
jaseg
